### PR TITLE
Add CODEOWNERS and Maintainers section

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @GeiserX @david-alvarez-rosa

--- a/README.md
+++ b/README.md
@@ -88,6 +88,15 @@ For the badge (grande):
 
 <!--lint enable double-link-->
 
+## Maintainers
+
+<!--lint disable awesome-list-item-->
+
+- [@GeiserX](https://github.com/GeiserX)
+- [@david-alvarez-rosa](https://github.com/david-alvarez-rosa)
+
+<!--lint enable awesome-list-item-->
+
 ## Contribuir
 
 Las contribuciones bienvenidas. Lee las [directrices de contribución](contributing.md) antes de enviar un pull request.


### PR DESCRIPTION
Add `david-alvarez-rosa` as co-maintainer:

- **CODEOWNERS**: `* @GeiserX @david-alvarez-rosa` — ensures PR reviews are requested from both maintainers
- **README.md**: New `## Maintainers` section listing both, matching the format used in awesome-la-rioja