### PR TITLE
ci: use GitHub-hosted ubuntu-latest runners

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,11 +6,7 @@ on:
     branches: [main]
 jobs:
   lint:
-    runs-on: [self-hosted, Linux, X64]
-    # Do not run untrusted fork PR code on the self-hosted runner.
-    if: >-
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: GeiserX/awesome-lint-extra@v1.1.0
@@ -19,11 +15,7 @@ jobs:
           badge_types: '["stars", "last-commit", "language", "license"]'
           check_alphabetical: 'true'
   links:
-    runs-on: [self-hosted, Linux, X64]
-    # Do not run untrusted fork PR code on the self-hosted runner.
-    if: >-
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
     continue-on-error: true
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   stale:
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v10
         with:

--- a/.github/workflows/sync-maintainers.yml
+++ b/.github/workflows/sync-maintainers.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   sync:
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Summary
Switches self-hosted Linux CI jobs to GitHub-hosted `ubuntu-latest` (committed via API; repo is too large to clone).

## Why
Free+unlimited on public repos, frees the home-lab servers, runs PR code in isolated VMs (removes fork-PR attack surface). Removes the redundant fork-guard. Files: main.yml, stale.yml, sync-maintainers.yml


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow infrastructure to use GitHub-hosted runners instead of self-hosted runners across multiple automation jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->